### PR TITLE
#163191680 add the delete menu endpoint

### DIFF
--- a/app/api_v1/controllers/menus.py
+++ b/app/api_v1/controllers/menus.py
@@ -38,7 +38,14 @@ class Menu(Resource):
 
         Menu_model.update_menu(menu_to_update)
 
-        return {'Response':'Menu item updated'}, 200    
+        return {'Response':'Menu item updated'}, 200
+
+    def delete(self, menu_id):
+        ''' This function handles DELETE requests to the '/api_v1/menu/<menu_id>' route '''
+
+        Menu_model.delete_menu(menu_id)
+
+        return {'Response':'Menu item deleted'}, 200   
 
 
 class Menus(Resource):

--- a/app/api_v1/models/menus.py
+++ b/app/api_v1/models/menus.py
@@ -39,6 +39,20 @@ class Menu_model(object):
         cursor.close()
         connection.close()
 
+    @classmethod
+    def delete_menu(cls, menu_id):
+        ''' Deletes a menu item '''
+
+        connection = Database_setup.setup_conn('menus')
+        cursor = connection.cursor()
+
+        delete_menu_query = """ DELETE FROM menus_table WHERE menu_id=%s """
+        cursor.execute(delete_menu_query, (menu_id,))
+
+        connection.commit()
+        cursor.close()
+        connection.close()
+
 
 class Menus_model(object):
     ''' This class handles the Menus model '''


### PR DESCRIPTION
#### What does this PR do?
- Adds the delete menu items endpoint at the route: '/v1/menu/<menu_id>'
#### Description of Tasks to be completed?
- Developed the menu model
- Developed the menu endpoint controller
#### How should this be manually tested?
##### Database setup
- Install PostgreSQL on a local machine
- Create a 'MAIN' database on that machine
- Create a local user to the database with full rights to it, secured by a password
##### App setup and running
- Clone this repo to the local machine with the database above
- Navigate to the root of the repo: '/FastFoodFast
- Checkout the branch: 'ft-admin-menu-DELETE-163191680'
- Create a virtual environment > virtualenv <your_environment_name>
- Activate the virtual environment and install all app requirements: pip install -r requirements.txt
- Set/export environment variable APP_SETTINGS=development
- Set/export the other environmental variable specified in the .env file with your local details
- Run the app: 'python run.py' at the command prompt.
- The app server should run and give the URL at which it is listening for requests
##### Testing the app in Postman
- Install postman on the local machine
- Perform a GET request to the route: 'app_server_url/api_v1/menus' to retrieve all menus.
- Perform a DELETE request to this feature's route and pass in the menu_id in the url as an argument, for the order to delete: 'app_server_url/v1/menu/2'
- The response {"Response": "Menu item deleted"} should be returned.
- Repeat the GET request above to verify the order deletion as per below images:
#### What are the relevant pivotal tracker stories?
#163191680

![get12](https://user-images.githubusercontent.com/42747960/51597954-8f41c980-1f0d-11e9-8e55-f556ec1d7ed7.JPG)
![delete](https://user-images.githubusercontent.com/42747960/51597967-979a0480-1f0d-11e9-9a8e-61bb1e4e0653.JPG)
![get3](https://user-images.githubusercontent.com/42747960/51597984-9d8fe580-1f0d-11e9-9fc4-38ef72e9476e.JPG)
